### PR TITLE
fix an issue with eredis tcp connection in closed state and never recovers.

### DIFF
--- a/src/eredis_pool.app.src
+++ b/src/eredis_pool.app.src
@@ -1,7 +1,7 @@
 {application, eredis_pool,
  [
   {description, ""},
-  {vsn, "1.2"},
+  {vsn, "1.3"},
   {registered, []},
   {applications, [
                   kernel,


### PR DESCRIPTION
if redis tcp connection in closed state, exit the eredis process to allow poolboy restarting a new eredis with new connection