### PR TITLE
add poolboy to included_applications

### DIFF
--- a/src/eredis_pool.app.src
+++ b/src/eredis_pool.app.src
@@ -1,10 +1,10 @@
 {application, eredis_pool,
  [
   {description, "Pool of Redis connections"},
-  {vsn, "1.5.1"},
+  {vsn, "1.5.2"},
   {registered, []},
   {applications, [ kernel, stdlib ]},
-  {included_applications, [eredis]},
+  {included_applications, [eredis,poolboy]},
   {mod, {eredis_pool_app, []}},
   {env, [{pools, []}, {global_or_local, local}]}
 ]}.


### PR DESCRIPTION
Turns out this is needed otherwise relx won't include poolboy.