### PR TITLE
switch back to wooga/eredis 

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
              {preprocess, true}]}.
 
 {deps, [
-  {eredis,{git,"git@github.com:Kwisatx/eredis.git",{branch,"nonblocking_init"}}},
+  {eredis,{git,"https://github.com/wooga/eredis.git",{tag,"v1.2.0"}}},
   {poolboy,{git,"https://github.com/devinus/poolboy.git",{tag, "1.5.1"}}}
        ]
 }.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,6 @@
 [{<<"eredis">>,
-  {git,"git@github.com:Kwisatx/eredis.git",
-       {ref,"fef82307e4ce42dda2a5c1c0a6bc43eb3891ed57"}},
+  {git,"https://github.com/wooga/eredis.git",
+       {ref,"9ad91f149310a7d002cb966f62b7e2c3330abb04"}},
   0},
  {<<"poolboy">>,
   {git,"https://github.com/devinus/poolboy.git",

--- a/src/eredis_pool.app.src
+++ b/src/eredis_pool.app.src
@@ -1,7 +1,7 @@
 {application, eredis_pool,
  [
   {description, "Pool of Redis connections"},
-  {vsn, "1.5.2"},
+  {vsn, "1.5.3"},
   {registered, []},
   {applications, [ kernel, stdlib ]},
   {included_applications, [eredis,poolboy]},


### PR DESCRIPTION
as it has the non-blocking init patch now and is more actively maintained.

@hirotnk if this looks good and you could merge and tag I would appreciate it.  Also, if you would prefer to move this to a different organization (like https://github.com/dukesoferl where a few other erlang packages are moving), I could make you an owner in that org and you could move it there.  Up to you.